### PR TITLE
Sign out/token delete

### DIFF
--- a/app/(tabs)/(home,map,music,search,profile)/homeIndex.js
+++ b/app/(tabs)/(home,map,music,search,profile)/homeIndex.js
@@ -8,8 +8,11 @@ import { router } from "expo-router";
 
 const HomeScreen = ({}) => {
   const handleSignOut = async () => {
-    await AuthService.signOut();
-    router.replace("/welcome");
+    try{
+      await AuthService.signOut();
+    } catch(err) {
+      console.log("Error while signing out", err)
+    }
   };
 
   const handleRefreshTokens = async () => {

--- a/services/AuthService.js
+++ b/services/AuthService.js
@@ -190,7 +190,7 @@ export const AuthService = {
     } else {
       return;
     }
-  }
+  },
 
   // Refresh Tokens Function
   refreshTokens: async () => {

--- a/services/AuthService.js
+++ b/services/AuthService.js
@@ -155,40 +155,42 @@ export const AuthService = {
 
   // Sign Out Function
   // Deleting the tokens on the device from which logout performed.
-  // Routing to the Sign out page if token deletion successful.
+  // Routing to the welcome page if token deletion successful.
   signOut: async () => {
-
     try {
       await tokenManager.deleteTokens();
-      // Routing being handled wherever signOut called.
+      router.replace("/welcome");
     } catch(err) {
-      console.log(err, "Error deleting token while signing out");
+      console.log(err, "Error deleting token and routing while signing out");
     }
-
-    // const accessToken = await tokenManager?.getAccessToken();
-    // if (accessToken) {
-
-    //   try {
-    //     const response = await axiosPost({
-    //       url: `${serverURL}/signout`,
-    //       body: JSON.stringify({ accessToken }),
-    //       isAuthenticated: false
-    //     });
-
-
-    //     console.log('User Signed Out successfully:', response);
-    //     await tokenManager.deleteTokens();
-
-
-    //   } catch (err) {
-    //     console.error('Error:', err.message);
-    //     throw new Error(err.message);
-    //   }
-    // } else {
-    //   return;
-    // }
   },
 
+  // This invalidates cognito tokens, effectively signing out of all devices.
+  // Could be used in critical security cases.
+  globalSignOut: async() => {
+     const accessToken = await tokenManager?.getAccessToken();
+    if (accessToken) {
+
+      try {
+        const response = await axiosPost({
+          url: `${serverURL}/signout`,
+          body: JSON.stringify({ accessToken }),
+          isAuthenticated: false
+        });
+
+
+        console.log('User Signed Out successfully:', response);
+        await tokenManager.deleteTokens();
+
+
+      } catch (err) {
+        console.error('Error:', err.message);
+        throw new Error(err.message);
+      }
+    } else {
+      return;
+    }
+  }
 
   // Refresh Tokens Function
   refreshTokens: async () => {

--- a/services/AuthService.js
+++ b/services/AuthService.js
@@ -1,4 +1,5 @@
 
+import { router } from 'expo-router';
 import { axiosPost } from '../utils/axiosCalls';
 import { tokenManager } from '../utils/tokenManager';
 
@@ -153,30 +154,39 @@ export const AuthService = {
 
 
   // Sign Out Function
+  // Deleting the tokens on the device from which logout performed.
+  // Routing to the Sign out page if token deletion successful.
   signOut: async () => {
 
-    const accessToken = await tokenManager?.getAccessToken();
-    if (accessToken) {
-
-      try {
-        const response = await axiosPost({
-          url: `${serverURL}/signout`,
-          body: JSON.stringify({ accessToken }),
-          isAuthenticated: false
-        });
-
-
-        console.log('User Signed Out successfully:', response);
-        await tokenManager.deleteTokens();
-
-
-      } catch (err) {
-        console.error('Error:', err.message);
-        throw new Error(err.message);
-      }
-    } else {
-      return;
+    try {
+      await tokenManager.deleteTokens();
+      // Routing being handled wherever signOut called.
+    } catch(err) {
+      console.log(err, "Error deleting token while signing out");
     }
+
+    // const accessToken = await tokenManager?.getAccessToken();
+    // if (accessToken) {
+
+    //   try {
+    //     const response = await axiosPost({
+    //       url: `${serverURL}/signout`,
+    //       body: JSON.stringify({ accessToken }),
+    //       isAuthenticated: false
+    //     });
+
+
+    //     console.log('User Signed Out successfully:', response);
+    //     await tokenManager.deleteTokens();
+
+
+    //   } catch (err) {
+    //     console.error('Error:', err.message);
+    //     throw new Error(err.message);
+    //   }
+    // } else {
+    //   return;
+    // }
   },
 
 


### PR DESCRIPTION
- Created a new sign out function in auth service, which deletes tokens and re routes to welcome page.
- Removed routing done in the welcome page component in handleSignOut function.
- Renamed the existing sign out function to globalSignOut, which handles signing out globally from all devices, not being used anywhere right now though.